### PR TITLE
Simplified errors, add std::error::Error interop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = [
   "generate_assets.sh",
   "assets/*",
 ]
-homepag = "https://github.com/szarykott/datadog-logs"
+homepage = "https://github.com/szarykott/datadog-logs"
 keywords = ["logging", "datadog"]
 license = "MIT"
 name = "datadog-logs"
@@ -30,6 +30,7 @@ log = {version = "0.4", features = ["std"]}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0"}
 url = {version = "2.1"}
+thiserror = "1.0.24"
 # optional
 async-trait = {version = "0.1.42", optional = true}
 futures = {version = "0.3.8", optional = true}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,77 +1,31 @@
-use std::convert::From;
-use std::fmt::Display;
+use thiserror::Error;
 
 /// Errors for DataDogLogger
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum DataDogLoggerError {
     /// Error that can happen if DataDog URL is not valid
-    UrlParsingError(url::ParseError),
+    #[error("{0}")]
+    UrlParsingError(#[from] url::ParseError),
     /// Error that can happen during serialization of message
-    MessageSerializationError(serde_json::Error),
+    #[error("{0}")]
+    MessageSerializationError(#[from] serde_json::Error),
     /// I/O error
-    IoError(std::io::Error),
+    #[error("{0}")]
+    IoError(#[from] std::io::Error),
     /// Logger configuration error
+    #[error("{0}")]
     ConfigError(String),
     /// Generic error container
+    #[error("{0}")]
     OtherError(String),
     /// Http logger error
-    HttpError(attohttpc::Error),
+    #[error("{0}")]
+    HttpError(#[from] attohttpc::Error),
     /// Error that can happen during DataDogLogger initialization with log
-    LogIntegrationError(log::SetLoggerError),
+    #[error("{0}")]
+    LogIntegrationError(#[from] log::SetLoggerError),
     /// Http error in non blocking client
     #[cfg(feature = "nonblocking")]
-    AsyncHttpError(reqwest::Error),
-}
-
-impl Display for DataDogLoggerError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            DataDogLoggerError::UrlParsingError(e) => write!(f, "{}", e),
-            DataDogLoggerError::MessageSerializationError(e) => write!(f, "{}", e),
-            DataDogLoggerError::IoError(e) => write!(f, "{}", e),
-            DataDogLoggerError::ConfigError(e) => write!(f, "{}", e),
-            DataDogLoggerError::OtherError(e) => write!(f, "{}", e),
-            DataDogLoggerError::HttpError(e) => write!(f, "{}", e),
-            DataDogLoggerError::LogIntegrationError(e) => write!(f, "{}", e),
-            #[cfg(feature = "nonblocking")]
-            DataDogLoggerError::AsyncHttpError(e) => write!(f, "{}", e),
-        }
-    }
-}
-
-impl From<url::ParseError> for DataDogLoggerError {
-    fn from(e: url::ParseError) -> Self {
-        DataDogLoggerError::UrlParsingError(e)
-    }
-}
-
-impl From<serde_json::Error> for DataDogLoggerError {
-    fn from(e: serde_json::Error) -> Self {
-        DataDogLoggerError::MessageSerializationError(e)
-    }
-}
-
-impl From<std::io::Error> for DataDogLoggerError {
-    fn from(e: std::io::Error) -> Self {
-        DataDogLoggerError::IoError(e)
-    }
-}
-
-impl From<attohttpc::Error> for DataDogLoggerError {
-    fn from(e: attohttpc::Error) -> Self {
-        DataDogLoggerError::HttpError(e)
-    }
-}
-
-impl From<log::SetLoggerError> for DataDogLoggerError {
-    fn from(e: log::SetLoggerError) -> Self {
-        DataDogLoggerError::LogIntegrationError(e)
-    }
-}
-
-#[cfg(feature = "nonblocking")]
-impl From<reqwest::Error> for DataDogLoggerError {
-    fn from(e: reqwest::Error) -> Self {
-        DataDogLoggerError::AsyncHttpError(e)
-    }
+    #[error("{0}")]
+    AsyncHttpError(#[from] reqwest::Error),
 }


### PR DESCRIPTION
This PR uses thiserror to derive errors. The main benefit is derivation of `std::error::Error` which improves interop (lets us use anyhow in particular) but it also simplifies the code quite a bit.